### PR TITLE
Fix admin menu links to correct pages

### DIFF
--- a/admin/afiliados.php
+++ b/admin/afiliados.php
@@ -1634,7 +1634,7 @@ $influencers_count = count(array_filter($afiliados, function($a) { return $a['in
         <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -1642,19 +1642,19 @@ $influencers_count = count(array_filter($afiliados, function($a) { return $a['in
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item active">
+                <a href="/admin/afiliados.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -1662,23 +1662,23 @@ $influencers_count = count(array_filter($afiliados, function($a) { return $a['in
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/banners.php
+++ b/admin/banners.php
@@ -1007,7 +1007,7 @@ $nome = $nome ? explode(' ', $nome)[0] : null;
         <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -1015,19 +1015,19 @@ $nome = $nome ? explode(' ', $nome)[0] : null;
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -1035,23 +1035,23 @@ $nome = $nome ? explode(' ', $nome)[0] : null;
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-dollar-sign"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item active">
+                <a href="/admin/banners.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/cartelas.php
+++ b/admin/cartelas.php
@@ -1275,7 +1275,7 @@ if (!empty($premios)) {
         <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -1283,19 +1283,19 @@ if (!empty($premios)) {
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -1303,23 +1303,23 @@ if (!empty($premios)) {
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item active">
+                <a href="/admin/cartelas.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/components/header.php
+++ b/admin/components/header.php
@@ -129,25 +129,25 @@
         <p onclick="window.location.href='/admin'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-chart-line"></i> Dashboard
         </p>
-        <p onclick="window.location.href='config.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
+        <p onclick="window.location.href='/admin/config.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-gear"></i> Configurações
         </p>
-        <p onclick="window.location.href='gateway.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
+        <p onclick="window.location.href='/admin/gateway.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-landmark"></i> Gateway
         </p>
-        <p onclick="window.location.href='usuarios.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
+        <p onclick="window.location.href='/admin/usuarios.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-users"></i> Usuários
         </p>
-        <p onclick="window.location.href='afiliados.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
+        <p onclick="window.location.href='/admin/afiliados.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-people-arrows"></i> Afiliados
         </p>
-        <p onclick="window.location.href='cartelas.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
+        <p onclick="window.location.href='/admin/cartelas.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-gem"></i> Raspadinhas
         </p>
-        <p onclick="window.location.href='depositos.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
+        <p onclick="window.location.href='/admin/depositos.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-plus-circle"></i> Depósitos
         </p>
-        <p onclick="window.location.href='saques.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
+        <p onclick="window.location.href='/admin/saques.php'" class="nav-item-enhanced flex items-center gap-4 cursor-pointer" style="padding-left: 16px;"> 
             <i class="fa-solid fa-minus-circle"></i> Saques
         </p>
         

--- a/admin/config.php
+++ b/admin/config.php
@@ -814,7 +814,7 @@ $nome = $nome ? explode(' ', $nome)[0] : null;
        <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -822,19 +822,19 @@ $nome = $nome ? explode(' ', $nome)[0] : null;
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -842,23 +842,23 @@ $nome = $nome ? explode(' ', $nome)[0] : null;
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item active">
+                <a href="/admin/config.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/depositos.php
+++ b/admin/depositos.php
@@ -841,7 +841,7 @@ $valor_total_pendente = array_sum(array_column($depositos_pendentes, 'valor'));
        <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -849,19 +849,19 @@ $valor_total_pendente = array_sum(array_column($depositos_pendentes, 'valor'));
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item active">
+                <a href="/admin/depositos.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -869,23 +869,23 @@ $valor_total_pendente = array_sum(array_column($depositos_pendentes, 'valor'));
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/gateway.php
+++ b/admin/gateway.php
@@ -860,7 +860,7 @@ if (!$gatewayproprio) {
        <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -868,19 +868,19 @@ if (!$gatewayproprio) {
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -888,23 +888,23 @@ if (!$gatewayproprio) {
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item active">
+                <a href="/admin/gateway.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/index.php
+++ b/admin/index.php
@@ -866,7 +866,7 @@ $saques_recentes = $stmt->fetchAll(PDO::FETCH_ASSOC);
        <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item active">
+                <a href="/admin/index.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -874,19 +874,19 @@ $saques_recentes = $stmt->fetchAll(PDO::FETCH_ASSOC);
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -894,23 +894,23 @@ $saques_recentes = $stmt->fetchAll(PDO::FETCH_ASSOC);
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/saques.php
+++ b/admin/saques.php
@@ -1202,7 +1202,7 @@ $activeGateway = $stmt->fetchColumn();
        <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -1210,19 +1210,19 @@ $activeGateway = $stmt->fetchColumn();
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item">
+                <a href="/admin/usuarios.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item active">
+                <a href="/admin/saques.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -1230,23 +1230,23 @@ $activeGateway = $stmt->fetchColumn();
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>

--- a/admin/usuarios.php
+++ b/admin/usuarios.php
@@ -1134,7 +1134,7 @@ $total_saldo = array_sum(array_column($usuarios, 'saldo'));
        <nav class="nav-menu">
             <div class="nav-section">
                 <div class="nav-section-title">Principal</div>
-                <a href="index.php" class="nav-item">
+                <a href="/admin/index.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-chart-pie"></i></div>
                     <div class="nav-text">Dashboard</div>
                 </a>
@@ -1142,19 +1142,19 @@ $total_saldo = array_sum(array_column($usuarios, 'saldo'));
             
             <div class="nav-section">
                 <div class="nav-section-title">Gestão</div>
-                <a href="usuarios.php" class="nav-item active">
+                <a href="/admin/usuarios.php" class="nav-item active">
                     <div class="nav-icon"><i class="fas fa-user"></i></div>
                     <div class="nav-text">Usuários</div>
                 </a>
-                <a href="afiliados.php" class="nav-item">
+                <a href="/admin/afiliados.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-user-plus"></i></div>
                     <div class="nav-text">Afiliados</div>
                 </a>
-                <a href="depositos.php" class="nav-item">
+                <a href="/admin/depositos.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-credit-card"></i></div>
                     <div class="nav-text">Depósitos</div>
                 </a>
-                <a href="saques.php" class="nav-item">
+                <a href="/admin/saques.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-money-bill-wave"></i></div>
                     <div class="nav-text">Saques</div>
                 </a>
@@ -1162,23 +1162,23 @@ $total_saldo = array_sum(array_column($usuarios, 'saldo'));
             
             <div class="nav-section">
                 <div class="nav-section-title">Sistema</div>
-                <a href="config.php" class="nav-item">
+                <a href="/admin/config.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-cogs"></i></div>
                     <div class="nav-text">Configurações</div>
                 </a>
-                <a href="gateway.php" class="nav-item">
+                <a href="/admin/gateway.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-usd"></i></div>
                     <div class="nav-text">Gateway</div>
                 </a>
-                <a href="banners.php" class="nav-item">
+                <a href="/admin/banners.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-images"></i></div>
                     <div class="nav-text">Banners</div>
                 </a>
-                <a href="cartelas.php" class="nav-item">
+                <a href="/admin/cartelas.php" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-diamond"></i></div>
                     <div class="nav-text">Raspadinhas</div>
                 </a>
-                <a href="../logout" class="nav-item">
+                <a href="/logout" class="nav-item">
                     <div class="nav-icon"><i class="fas fa-sign-out-alt"></i></div>
                     <div class="nav-text">Sair</div>
                 </a>


### PR DESCRIPTION
## Summary
- Use absolute `/admin/` paths in sidebar and header navigation
- Link logout to `/logout`

## Testing
- `php -l admin/index.php admin/usuarios.php admin/afiliados.php admin/depositos.php admin/gateway.php admin/saques.php admin/banners.php admin/cartelas.php admin/config.php admin/components/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e995052c832199ffb22a7fc807a2